### PR TITLE
Create objective-c category and swift extensions; also

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -97,7 +97,7 @@
   if (self.recordMode) { \
     \
     NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%@%@", referenceImageDirectory, suffixes__.firstObject]; \
-    BOOL referenceImageSaved__ = [self compareSnapshotOf ## what__ :(viewLayerOrImage__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) tolerance:(tolerance__) error:&error__]; \
+    BOOL referenceImageSaved__ = [self __FBSnapshotTestCase__compareSnapshotOf ## what__ :(viewLayerOrImage__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) tolerance:(tolerance__) error:&error__]; \
     if (!referenceImageSaved__) { \
       [errors__ addObject:error__]; \
     } \
@@ -105,10 +105,10 @@
     \
     for (NSString *suffix__ in suffixes__) { \
       NSString *referenceImagesDirectory__ = [NSString stringWithFormat:@"%@%@", referenceImageDirectory, suffix__]; \
-      BOOL referenceImageAvailable = [self referenceImageRecordedInDirectory:referenceImagesDirectory__ identifier:(identifier__) scale:[self scaleOfViewLayerOrImage:viewLayerOrImage__] error:&error__]; \
+      BOOL referenceImageAvailable = [self __FBSnapshotTestCase__referenceImageRecordedInDirectory:referenceImagesDirectory__ identifier:(identifier__) scale:[self __FBSnapshotTestCase__scaleOfViewLayerOrImage:viewLayerOrImage__] error:&error__]; \
       \
       if (referenceImageAvailable) { \
-        BOOL comparisonSuccess__ = [self compareSnapshotOf ## what__ :(viewLayerOrImage__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) tolerance:(tolerance__) error:&error__]; \
+        BOOL comparisonSuccess__ = [self __FBSnapshotTestCase__compareSnapshotOf ## what__ :(viewLayerOrImage__) referenceImagesDirectory:referenceImagesDirectory__ identifier:(identifier__) tolerance:(tolerance__) error:&error__]; \
         [errors__ removeAllObjects]; \
         if (comparisonSuccess__) { \
           testSuccess__ = YES; \
@@ -143,6 +143,82 @@
  }
  @endcode
  */
+@interface XCTestCase (FBSnapshotTestCase)
+
+@property (nonatomic) FBSnapshotTestController *__FBSnapshotTestCase__snapshotController;
+
+
+/**
+ Performs the comparison or records a snapshot of the layer if recordMode is YES.
+ @param layer The Layer to snapshot
+ @param referenceImagesDirectory The directory in which reference images are stored.
+ @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
+ @param tolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care
+ @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+ @returns YES if the comparison (or saving of the reference image) succeeded.
+ */
+- (BOOL)__FBSnapshotTestCase__compareSnapshotOfLayer:(CALayer *)layer
+                            referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                                          identifier:(NSString *)identifier
+                                           tolerance:(CGFloat)tolerance
+                                               error:(NSError **)errorPtr;
+
+/**
+ Performs the comparison or records a snapshot of the view if recordMode is YES.
+ @param view The view to snapshot
+ @param referenceImagesDirectory The directory in which reference images are stored.
+ @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
+ @param tolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care
+ @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+ @returns YES if the comparison (or saving of the reference image) succeeded.
+ */
+- (BOOL)__FBSnapshotTestCase__compareSnapshotOfView:(UIView *)view
+                           referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                                         identifier:(NSString *)identifier
+                                          tolerance:(CGFloat)tolerance
+                                              error:(NSError **)errorPtr;
+
+/**
+ Performs the comparison or records a snapshot of the image if recordMode is YES.
+ @param image The image to snapshot
+ @param referenceImagesDirectory The directory in which reference images are stored.
+ @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
+ @param tolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care
+ @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+ @returns YES if the comparison (or saving of the reference image) succeeded.
+ */
+- (BOOL)__FBSnapshotTestCase__compareSnapshotOfImage:(UIImage *)image
+                            referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                                          identifier:(NSString *)identifier
+                                           tolerance:(CGFloat)tolerance
+                                               error:(NSError **)errorPtr;
+
+/**
+ Checks if reference image with identifier based name exists in the reference images directory.
+ @param referenceImagesDirectory The directory in which reference images are stored.
+ @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
+ @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
+ @returns YES if reference image exists.
+ */
+- (BOOL)__FBSnapshotTestCase__referenceImageRecordedInDirectory:(NSString *)referenceImagesDirectory
+                                                     identifier:(NSString *)identifier
+                                                          scale:(CGFloat)scale
+                                                          error:(NSError **)errorPtr;
+
+- (CGFloat)__FBSnapshotTestCase__scaleOfViewLayerOrImage:(id)viewLayerOrImage;
+
+/**
+ Returns the reference image directory.
+
+ Helper function used to implement the assert macros.
+
+ @param dir directory to use if environment variable not specified. Ignored if null or empty.
+ */
+- (NSString *)getReferenceImageDirectoryWithDefault:(NSString *)dir;
+
+@end
+
+
 @interface FBSnapshotTestCase : XCTestCase
 
 /**
@@ -163,79 +239,8 @@
  - UIAppearance #91
  - Size Classes #92
  
- @attention If the view does't belong to a UIWindow, it will create one and add the view as a subview.
+ @attention If the view does't belong to a UIWindow, it will create one and add the view                  as a subview.
  */
 @property (readwrite, nonatomic, assign) BOOL usesDrawViewHierarchyInRect;
-
-- (void)setUp NS_REQUIRES_SUPER;
-- (void)tearDown NS_REQUIRES_SUPER;
-
-/**
- Performs the comparison or records a snapshot of the layer if recordMode is YES.
- @param layer The Layer to snapshot
- @param referenceImagesDirectory The directory in which reference images are stored.
- @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
- @param tolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care
- @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
- @returns YES if the comparison (or saving of the reference image) succeeded.
- */
-- (BOOL)compareSnapshotOfLayer:(CALayer *)layer
-      referenceImagesDirectory:(NSString *)referenceImagesDirectory
-                    identifier:(NSString *)identifier
-                     tolerance:(CGFloat)tolerance
-                         error:(NSError **)errorPtr;
-
-/**
- Performs the comparison or records a snapshot of the view if recordMode is YES.
- @param view The view to snapshot
- @param referenceImagesDirectory The directory in which reference images are stored.
- @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
- @param tolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care
- @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
- @returns YES if the comparison (or saving of the reference image) succeeded.
- */
-- (BOOL)compareSnapshotOfView:(UIView *)view
-     referenceImagesDirectory:(NSString *)referenceImagesDirectory
-                   identifier:(NSString *)identifier
-                    tolerance:(CGFloat)tolerance
-                        error:(NSError **)errorPtr;
-
-/**
- Performs the comparison or records a snapshot of the image if recordMode is YES.
- @param image The image to snapshot
- @param referenceImagesDirectory The directory in which reference images are stored.
- @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
- @param tolerance The percentage difference to still count as identical - 0 mean pixel perfect, 1 means I don't care
- @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
- @returns YES if the comparison (or saving of the reference image) succeeded.
- */
-- (BOOL)compareSnapshotOfImage:(UIImage *)image
-      referenceImagesDirectory:(NSString *)referenceImagesDirectory
-                    identifier:(NSString *)identifier
-                     tolerance:(CGFloat)tolerance
-                         error:(NSError **)errorPtr;
-
-/**
- Checks if reference image with identifier based name exists in the reference images directory.
- @param referenceImagesDirectory The directory in which reference images are stored.
- @param identifier An optional identifier, used if there are multiple snapshot tests in a given -test method.
- @param errorPtr An error to log in an XCTAssert() macro if the method fails (missing reference image, images differ, etc).
- @returns YES if reference image exists.
- */
-- (BOOL)referenceImageRecordedInDirectory:(NSString *)referenceImagesDirectory
-                               identifier:(NSString *)identifier
-                                    scale:(CGFloat)scale
-                                    error:(NSError **)errorPtr;
-
-- (CGFloat)scaleOfViewLayerOrImage:(id)viewLayerOrImage;
-
-/**
- Returns the reference image directory.
-
- Helper function used to implement the assert macros.
-
- @param dir directory to use if environment variable not specified. Ignored if null or empty.
- */
-- (NSString *)getReferenceImageDirectoryWithDefault:(NSString *)dir;
 
 @end

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -11,117 +11,98 @@
 #import <FBSnapshotTestCase/FBSnapshotTestCase.h>
 #import <FBSnapshotTestCase/FBSnapshotTestController.h>
 
-@implementation FBSnapshotTestCase
+#import <objc/runtime.h>
+
+
+@implementation XCTestCase (FBSnapshotTestCase)
+
+@dynamic __FBSnapshotTestCase__snapshotController;
+
+
+static char __FBSnapshotTestCase__snapshotControllerKey[] = "__FBSnapshotTestCase__snapshotController";
+
+- (void)__FBSnapshotTestCase__setSnapshotController:(FBSnapshotTestController *)snapshotController
 {
-  FBSnapshotTestController *_snapshotController;
+  objc_setAssociatedObject(self,
+                           __FBSnapshotTestCase__snapshotControllerKey,
+                           snapshotController,
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
-#pragma mark - Overrides
-
-- (void)setUp
+- (FBSnapshotTestController *)__FBSnapshotTestCase__snapshotController
 {
-  [super setUp];
-  _snapshotController = [[FBSnapshotTestController alloc] initWithTestName:NSStringFromClass([self class])];
+  
+  FBSnapshotTestController *sc = objc_getAssociatedObject(self, __FBSnapshotTestCase__snapshotControllerKey);
+  if (!sc || (sc.invocation != self.invocation)) {
+    sc = [[FBSnapshotTestController alloc] initWithTestName:NSStringFromClass([self class])
+                                                 invocation:self.invocation];
+    [self __FBSnapshotTestCase__setSnapshotController: sc];
+  }
+  
+  return sc;
+  
 }
 
-- (void)tearDown
-{
-  _snapshotController = nil;
-  [super tearDown];
-}
-
-- (BOOL)recordMode
-{
-  return _snapshotController.recordMode;
-}
-
-- (void)setRecordMode:(BOOL)recordMode
-{
-  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
-  _snapshotController.recordMode = recordMode;
-}
-
-- (BOOL)isDeviceAgnostic
-{
-  return _snapshotController.deviceAgnostic;
-}
-
-- (void)setDeviceAgnostic:(BOOL)deviceAgnostic
-{
-  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
-  _snapshotController.deviceAgnostic = deviceAgnostic;
-}
-
-- (BOOL)usesDrawViewHierarchyInRect
-{
-  return _snapshotController.usesDrawViewHierarchyInRect;
-}
-
-- (void)setUsesDrawViewHierarchyInRect:(BOOL)usesDrawViewHierarchyInRect
-{
-  NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
-  _snapshotController.usesDrawViewHierarchyInRect = usesDrawViewHierarchyInRect;
-}
 
 #pragma mark - Public API
 
-- (BOOL)compareSnapshotOfLayer:(CALayer *)layer
-      referenceImagesDirectory:(NSString *)referenceImagesDirectory
-                    identifier:(NSString *)identifier
-                     tolerance:(CGFloat)tolerance
-                         error:(NSError **)errorPtr
+- (BOOL)__FBSnapshotTestCase__compareSnapshotOfLayer:(CALayer *)layer
+                            referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                                          identifier:(NSString *)identifier
+                                           tolerance:(CGFloat)tolerance
+                                               error:(NSError **)errorPtr
 {
-  return [self _compareSnapshotOfViewLayerOrImage:layer
-                         referenceImagesDirectory:referenceImagesDirectory
-                                       identifier:identifier
-                                        tolerance:tolerance
-                                            error:errorPtr];
+  return [self __FBSnapshotTestCase__compareSnapshotOfViewLayerOrImage:layer
+                                              referenceImagesDirectory:referenceImagesDirectory
+                                                            identifier:identifier
+                                                             tolerance:tolerance
+                                                                 error:errorPtr];
 }
 
-- (BOOL)compareSnapshotOfView:(UIView *)view
-     referenceImagesDirectory:(NSString *)referenceImagesDirectory
-                   identifier:(NSString *)identifier
-                    tolerance:(CGFloat)tolerance
-                        error:(NSError **)errorPtr
+- (BOOL)__FBSnapshotTestCase__compareSnapshotOfView:(UIView *)view
+                           referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                                         identifier:(NSString *)identifier
+                                          tolerance:(CGFloat)tolerance
+                                              error:(NSError **)errorPtr
 {
-  return [self _compareSnapshotOfViewLayerOrImage:view
-                         referenceImagesDirectory:referenceImagesDirectory
-                                       identifier:identifier
-                                        tolerance:tolerance
-                                            error:errorPtr];
+  return [self __FBSnapshotTestCase__compareSnapshotOfViewLayerOrImage:view
+                                              referenceImagesDirectory:referenceImagesDirectory
+                                                            identifier:identifier
+                                                             tolerance:tolerance
+                                                                 error:errorPtr];
 }
 
-- (BOOL)compareSnapshotOfImage:(UIImage *)image
-      referenceImagesDirectory:(NSString *)referenceImagesDirectory
-                    identifier:(NSString *)identifier
-                     tolerance:(CGFloat)tolerance
-                         error:(NSError **)errorPtr
+- (BOOL)__FBSnapshotTestCase__compareSnapshotOfImage:(UIImage *)image
+                            referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                                          identifier:(NSString *)identifier
+                                           tolerance:(CGFloat)tolerance
+                                               error:(NSError **)errorPtr
 {
-  return [self _compareSnapshotOfViewLayerOrImage:image
-                         referenceImagesDirectory:referenceImagesDirectory
-                                       identifier:identifier
-                                        tolerance:tolerance
-                                            error:errorPtr];
+  return [self __FBSnapshotTestCase__compareSnapshotOfViewLayerOrImage:image
+                                              referenceImagesDirectory:referenceImagesDirectory
+                                                            identifier:identifier
+                                                             tolerance:tolerance
+                                                                 error:errorPtr];
 }
 
-- (BOOL)referenceImageRecordedInDirectory:(NSString *)referenceImagesDirectory
-                               identifier:(NSString *)identifier
-                                    scale:(CGFloat)scale
-                                    error:(NSError **)errorPtr
+- (BOOL)__FBSnapshotTestCase__referenceImageRecordedInDirectory:(NSString *)referenceImagesDirectory
+                                                     identifier:(NSString *)identifier
+                                                          scale:(CGFloat)scale
+                                                          error:(NSError **)errorPtr
 {
-    NSAssert1(_snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
-    _snapshotController.referenceImagesDirectory = referenceImagesDirectory;
-    UIImage *referenceImage = [_snapshotController referenceImageForSelector:self.invocation.selector
-                                                                  identifier:identifier
-                                                                       scale:scale
-                                                                       error:errorPtr];
-
-    return (referenceImage != nil);
+  NSAssert1(self.__FBSnapshotTestCase__snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  self.__FBSnapshotTestCase__snapshotController.referenceImagesDirectory = referenceImagesDirectory;
+  UIImage *referenceImage = [self.__FBSnapshotTestCase__snapshotController referenceImageForSelector:self.invocation.selector
+                                                                                          identifier:identifier
+                                                                                               scale:scale
+                                                                                               error:errorPtr];
+  
+  return (referenceImage != nil);
 }
 
-- (CGFloat)scaleOfViewLayerOrImage:(id)viewLayerOrImage
+- (CGFloat)__FBSnapshotTestCase__scaleOfViewLayerOrImage:(id)viewLayerOrImage
 {
-  return [_snapshotController scaleOfViewLayerOrImage:viewLayerOrImage];
+  return [self.__FBSnapshotTestCase__snapshotController scaleOfViewLayerOrImage:viewLayerOrImage];
 }
 
 - (NSString *)getReferenceImageDirectoryWithDefault:(NSString *)dir
@@ -139,18 +120,59 @@
 
 #pragma mark - Private API
 
-- (BOOL)_compareSnapshotOfViewLayerOrImage:(id)viewLayerOrImage
-             referenceImagesDirectory:(NSString *)referenceImagesDirectory
-                           identifier:(NSString *)identifier
-                            tolerance:(CGFloat)tolerance
-                                error:(NSError **)errorPtr
+- (BOOL)__FBSnapshotTestCase__compareSnapshotOfViewLayerOrImage:(id)viewLayerOrImage
+                                       referenceImagesDirectory:(NSString *)referenceImagesDirectory
+                                                     identifier:(NSString *)identifier
+                                                      tolerance:(CGFloat)tolerance
+                                                          error:(NSError **)errorPtr
 {
-  _snapshotController.referenceImagesDirectory = referenceImagesDirectory;
-  return [_snapshotController compareSnapshotOfViewLayerOrImage:viewLayerOrImage
-                                                       selector:self.invocation.selector
-                                                     identifier:identifier
-                                                      tolerance:tolerance
-                                                          error:errorPtr];
+  self.__FBSnapshotTestCase__snapshotController.referenceImagesDirectory = referenceImagesDirectory;
+  return [self.__FBSnapshotTestCase__snapshotController compareSnapshotOfViewLayerOrImage:viewLayerOrImage
+                                                                                 selector:self.invocation.selector
+                                                                               identifier:identifier
+                                                                                tolerance:tolerance
+                                                                                    error:errorPtr];
+}
+
+
+@end
+
+
+@implementation FBSnapshotTestCase
+
+#pragma mark - Overrides
+
+- (BOOL)recordMode
+{
+  return self.__FBSnapshotTestCase__snapshotController.recordMode;
+}
+
+- (void)setRecordMode:(BOOL)recordMode
+{
+  NSAssert1(self.__FBSnapshotTestCase__snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  self.__FBSnapshotTestCase__snapshotController.recordMode = recordMode;
+}
+
+- (BOOL)isDeviceAgnostic
+{
+  return self.__FBSnapshotTestCase__snapshotController.deviceAgnostic;
+}
+
+- (void)setDeviceAgnostic:(BOOL)deviceAgnostic
+{
+  NSAssert1(self.__FBSnapshotTestCase__snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  self.__FBSnapshotTestCase__snapshotController.deviceAgnostic = deviceAgnostic;
+}
+
+- (BOOL)usesDrawViewHierarchyInRect
+{
+  return self.__FBSnapshotTestCase__snapshotController.usesDrawViewHierarchyInRect;
+}
+
+- (void)setUsesDrawViewHierarchyInRect:(BOOL)usesDrawViewHierarchyInRect
+{
+  NSAssert1(self.__FBSnapshotTestCase__snapshotController, @"%s cannot be called before [super setUp]", __FUNCTION__);
+  self.__FBSnapshotTestCase__snapshotController.usesDrawViewHierarchyInRect = usesDrawViewHierarchyInRect;
 }
 
 @end

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -71,18 +71,20 @@ extern NSString *const FBDiffedImageKey;
  */
 @property (readwrite, nonatomic, copy) NSString *referenceImagesDirectory;
 
+@property (nonatomic, readonly) NSInvocation *invocation;
+
 /**
  @param testClass The subclass of FBSnapshotTestCase that is using this controller.
  @returns An instance of FBSnapshotTestController.
  */
-- (instancetype)initWithTestClass:(Class)testClass;
+- (instancetype)initWithTestClass:(Class)testClass invocation:(NSInvocation *)invocation;
 
 /**
  Designated initializer.
  @param testName The name of the tests.
  @returns An instance of FBSnapshotTestController.
  */
-- (instancetype)initWithTestName:(NSString *)testName;
+- (instancetype)initWithTestName:(NSString *)testName invocation:(NSInvocation *)invocation;
 
 /**
  Performs the comparison of the layer.

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -29,6 +29,11 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
   FBTestSnapshotFileNameTypeFailedTestDiff,
 };
 
+
+@interface FBSnapshotTestController()
+@property (nonatomic) NSInvocation *invocation;
+@end
+
 @implementation FBSnapshotTestController
 {
   NSString *_testName;
@@ -37,15 +42,16 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
 
 #pragma mark - Initializers
 
-- (instancetype)initWithTestClass:(Class)testClass;
+- (instancetype)initWithTestClass:(Class)testClass invocation:(NSInvocation *)invocation;
 {
-  return [self initWithTestName:NSStringFromClass(testClass)];
+  return [self initWithTestName:NSStringFromClass(testClass) invocation:invocation];
 }
 
-- (instancetype)initWithTestName:(NSString *)testName
+- (instancetype)initWithTestName:(NSString *)testName invocation:(NSInvocation *)invocation
 {
   if (self = [super init]) {
     _testName = [testName copy];
+    self.invocation = invocation;
     _deviceAgnostic = NO;
     
     _fileManager = [[NSFileManager alloc] init];

--- a/FBSnapshotTestCase/SwiftSupport.swift
+++ b/FBSnapshotTestCase/SwiftSupport.swift
@@ -8,7 +8,26 @@
 *
 */
 
-public extension FBSnapshotTestCase {
+
+import XCTest
+
+public protocol FBSnapshotCapableTestCase {
+  
+  var BSnapshotRecordMode: Bool {set get}
+  
+  func FBSnapshotVerifyView(view: UIView, identifier: String, suffixes: NSOrderedSet, tolerance: CGFloat, file: StaticString, line: UInt)
+  func FBSnapshotVerifyLayer(layer: CALayer, identifier: String, suffixes: NSOrderedSet, tolerance: CGFloat, file: StaticString, line: UInt)
+  func FBSnapshotVerifyImage(image: UIImage, identifier: String, suffixes: NSOrderedSet, tolerance: CGFloat, file: StaticString, line: UInt)
+  
+}
+
+public extension FBSnapshotCapableTestCase where Self: XCTestCase {
+  
+  public var BSnapshotRecordMode: Bool {
+    set { self.__FBSnapshotTestCase__snapshotController.recordMode = newValue }
+    get { return self.__FBSnapshotTestCase__snapshotController.recordMode }
+  }
+  
   public func FBSnapshotVerifyView(view: UIView, identifier: String = "", suffixes: NSOrderedSet = FBSnapshotTestCaseDefaultSuffixes(), tolerance: CGFloat = 0, file: StaticString = #file, line: UInt = #line) {
     FBSnapshotVerifyViewLayerOrImage(view, identifier: identifier, suffixes: suffixes, tolerance: tolerance, file: file, line: line)
   }
@@ -31,7 +50,7 @@ public extension FBSnapshotTestCase {
         let referenceImagesDirectory = "\(envReferenceImageDirectory)\(suffix)"
         if viewOrLayer.isKindOfClass(UIView) {
           do {
-            try compareSnapshotOfView(viewOrLayer as! UIView, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: tolerance)
+            try __FBSnapshotTestCase__compareSnapshotOfView(viewOrLayer as! UIView, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: tolerance)
             comparisonSuccess = true
           } catch let error1 as NSError {
             error = error1
@@ -39,7 +58,7 @@ public extension FBSnapshotTestCase {
           }
         } else if viewOrLayer.isKindOfClass(CALayer) {
           do {
-            try compareSnapshotOfLayer(viewOrLayer as! CALayer, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: tolerance)
+            try __FBSnapshotTestCase__compareSnapshotOfLayer(viewOrLayer as! CALayer, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: tolerance)
             comparisonSuccess = true
           } catch let error1 as NSError {
             error = error1
@@ -47,7 +66,7 @@ public extension FBSnapshotTestCase {
           }
         } else if viewOrLayer.isKindOfClass(UIImage) {
           do {
-            try compareSnapshotOfImage(viewOrLayer as! UIImage, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: tolerance)
+            try __FBSnapshotTestCase__compareSnapshotOfImage(viewOrLayer as! UIImage, referenceImagesDirectory: referenceImagesDirectory, identifier: identifier, tolerance: tolerance)
             comparisonSuccess = true
           } catch let error1 as NSError {
             error = error1
@@ -56,10 +75,10 @@ public extension FBSnapshotTestCase {
         } else {
           assertionFailure("Only UIView, CALayer or UIImage classes can be snapshotted")
         }
-
-        assert(recordMode == false, message: "Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!", file: file, line: line)
-
-        if comparisonSuccess || recordMode {
+        
+        assert(self.BSnapshotRecordMode == false, message: "Test ran in record mode. Reference image is now saved. Disable record mode to perform an actual snapshot comparison!", file: file, line: line)
+        
+        if comparisonSuccess || self.BSnapshotRecordMode {
           break
         }
 
@@ -76,3 +95,5 @@ public extension FBSnapshotTestCase {
     }
   }
 }
+
+extension FBSnapshotTestCase: FBSnapshotCapableTestCase {}

--- a/FBSnapshotTestCaseTests/FBSnapshotControllerTests.m
+++ b/FBSnapshotTestCaseTests/FBSnapshotControllerTests.m
@@ -27,7 +27,7 @@
     UIImage *testImage = [self _bundledImageNamed:@"square-copy" type:@"png"];
     XCTAssertNotNil(testImage);
 
-    FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil];
+    FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil invocation:nil];
     NSError *error = nil;
     XCTAssertTrue([controller compareReferenceImage:referenceImage toImage:testImage tolerance:0 error:&error]);
     XCTAssertNil(error);
@@ -40,7 +40,7 @@
     UIImage *testImage = [self _bundledImageNamed:@"square_with_text" type:@"png"];
     XCTAssertNotNil(testImage);
 
-    FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil];
+    FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil invocation:nil];
     NSError *error = nil;
     XCTAssertFalse([controller compareReferenceImage:referenceImage toImage:testImage tolerance:0 error:&error]);
     XCTAssertNotNil(error);
@@ -54,7 +54,7 @@
     UIImage *testImage = [self _bundledImageNamed:@"square_with_pixel" type:@"png"];
     XCTAssertNotNil(testImage);
 
-    FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil];
+    FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil invocation:nil];
     // With virtually no margin for error, this should fail to be equal
     NSError *error = nil;
     XCTAssertFalse([controller compareReferenceImage:referenceImage toImage:testImage tolerance:0.0001 error:&error]);
@@ -69,7 +69,7 @@
     UIImage *testImage = [self _bundledImageNamed:@"square_with_pixel" type:@"png"];
     XCTAssertNotNil(testImage);
 
-    FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil];
+    FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil invocation:nil];
     // With some tolerance these should be considered the same
     NSError *error = nil;
     XCTAssertTrue([controller compareReferenceImage:referenceImage toImage:testImage tolerance:.001 error:&error]);
@@ -83,7 +83,7 @@
   UIImage *testImage = [self _bundledImageNamed:@"rect" type:@"png"];
   XCTAssertNotNil(testImage);
   
-  FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil];
+  FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil invocation:nil];
   // With some tolerance these should be considered the same
   NSError *error = nil;
   XCTAssertFalse([controller compareReferenceImage:referenceImage toImage:testImage tolerance:0 error:&error]);
@@ -98,7 +98,7 @@
   UIImage *testImage = [self _bundledImageNamed:@"square_with_pixel" type:@"png"];
   XCTAssertNotNil(testImage);
   
-  FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil];
+  FBSnapshotTestController *controller = [[FBSnapshotTestController alloc] initWithTestClass:nil invocation:nil];
   [controller setDeviceAgnostic:YES];
   [controller setReferenceImagesDirectory:@"/dev/null/"];
   NSError *error = nil;


### PR DESCRIPTION
rename the category methods to include a prefix.

In stead of having to subclass from FBSnapshotTestCase, it is now
possible to use categories directly on XCTestCase through macros in
Ojbective-C, and in Swift protocol oriented programming is used to allow
each test class to be extended by adhering to the
FBSnapshotCapableTestCase protocol.
